### PR TITLE
Fix cast stripping to match latest version of decomp

### DIFF
--- a/fast64_internal/oot/oot_level_parser.py
+++ b/fast64_internal/oot/oot_level_parser.py
@@ -384,10 +384,9 @@ def parseRoomList(
         rf"\{{([\(\)\sA-Za-z0-9\_]*),([\(\)\sA-Za-z0-9\_]*)\}}\s*,", roomList, flags=re.DOTALL
     ):
         roomName = roomMatch.group(1).strip().replace("SegmentRomStart", "")
-        if "(u32)" in roomName:
-            roomName = roomName[5:].strip()[1:]  # includes leading underscore
-        else:
-            roomName = roomName[1:]
+
+        if "(uintptr_t)" in roomName:
+            roomName = roomName.replace("(uintptr_t)_", "")
 
         roomPath = os.path.join(sharedSceneData.scenePath, f"{roomName}.c")
         roomData = readFile(roomPath)


### PR DESCRIPTION
Very tiny fix. The room parser expects the elements of the .c RoomList to be prefixed with `(u32)_...` and the files themselves to be prefixed with a `_`. This is no longer the case in the mm decomp, the casts are now `(uintptr_t)` and the trailing `_` is not in the filenames.

e.g.

```
RomFile Z2_CLOCKTOWERRoomList0x000164[] = {
    { (uintptr_t)_Z2_CLOCKTOWER_room_00SegmentRomStart, (uintptr_t)_Z2_CLOCKTOWER_room_00SegmentRomEnd },
};
```